### PR TITLE
Show AltSignAddr Data req/resp in admin UI

### DIFF
--- a/database/altsignaddr_test.go
+++ b/database/altsignaddr_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 )
 
-func exampleAltSignAddrData() *AltSignAddrData {
-	return &AltSignAddrData{
+func exampleAltSignAddrData() AltSignAddrData {
+	return AltSignAddrData{
 		AltSignAddr: randString(35, addrCharset),
-		Req:         randBytes(1000),
+		Req:         randString(96, addrCharset),
 		ReqSig:      randString(96, sigCharset),
-		Resp:        randBytes(1000),
+		Resp:        randString(96, addrCharset),
 		RespSig:     randString(96, sigCharset),
 	}
 }
 
 // ensureData will confirm that the provided data exists in the database.
-func ensureData(t *testing.T, ticketHash string, wantData *AltSignAddrData) {
+func ensureData(t *testing.T, ticketHash string, wantData AltSignAddrData) {
 	t.Helper()
 
 	data, err := db.AltSignAddrData(ticketHash)
@@ -40,7 +40,7 @@ func testAltSignAddrData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error fetching alt sign address data: %v", err)
 	}
-	if h != nil {
+	if h != (AltSignAddrData{}) {
 		t.Fatal("expected no data")
 	}
 
@@ -57,7 +57,7 @@ func testInsertAltSignAddr(t *testing.T) {
 	ticketHash := randString(64, hexCharset)
 
 	// Not added yet so no values should exist in the db.
-	ensureData(t, ticketHash, nil)
+	ensureData(t, ticketHash, AltSignAddrData{})
 
 	data := exampleAltSignAddrData()
 	// Clear alt sign addr for test.
@@ -67,12 +67,12 @@ func testInsertAltSignAddr(t *testing.T) {
 		t.Fatalf("expected error for insert blank address")
 	}
 
-	if err := db.InsertAltSignAddr(ticketHash, nil); err == nil {
+	if err := db.InsertAltSignAddr(ticketHash, AltSignAddrData{}); err == nil {
 		t.Fatalf("expected error for nil data")
 	}
 
 	// Still no change on errors.
-	ensureData(t, ticketHash, nil)
+	ensureData(t, ticketHash, AltSignAddrData{})
 
 	// Re-add alt sig addr.
 	data.AltSignAddr = randString(35, addrCharset)
@@ -114,5 +114,5 @@ func testDeleteAltSignAddr(t *testing.T) {
 		t.Fatalf("unexpected error deleting alt sign addr: %v", err)
 	}
 
-	ensureData(t, ticketHash, nil)
+	ensureData(t, ticketHash, AltSignAddrData{})
 }

--- a/webapi/admin.go
+++ b/webapi/admin.go
@@ -38,12 +38,12 @@ type DcrdStatus struct {
 }
 
 type searchResult struct {
-	Hash           string
-	Found          bool
-	Ticket         database.Ticket
-	AltSignAddr    string
-	VoteChanges    map[uint32]database.VoteChangeRecord
-	MaxVoteChanges int
+	Hash            string
+	Found           bool
+	Ticket          database.Ticket
+	AltSignAddrData database.AltSignAddrData
+	VoteChanges     map[uint32]database.VoteChangeRecord
+	MaxVoteChanges  int
 }
 
 func dcrdStatus(c *gin.Context) DcrdStatus {
@@ -176,19 +176,14 @@ func ticketSearch(c *gin.Context) {
 		return
 	}
 
-	altSignAddr := ""
-	if altSignAddrData != nil {
-		altSignAddr = altSignAddrData.AltSignAddr
-	}
-
 	c.HTML(http.StatusOK, "admin.html", gin.H{
 		"SearchResult": searchResult{
-			Hash:           hash,
-			Found:          found,
-			Ticket:         ticket,
-			AltSignAddr:    altSignAddr,
-			VoteChanges:    voteChanges,
-			MaxVoteChanges: cfg.MaxVoteChangeRecords,
+			Hash:            hash,
+			Found:           found,
+			Ticket:          ticket,
+			AltSignAddrData: altSignAddrData,
+			VoteChanges:     voteChanges,
+			MaxVoteChanges:  cfg.MaxVoteChangeRecords,
 		},
 		"WebApiCache":  getCache(),
 		"WebApiCfg":    cfg,

--- a/webapi/middleware.go
+++ b/webapi/middleware.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/decred/dcrd/blockchain/stake/v4"
 	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
@@ -369,7 +370,7 @@ func vspAuth() gin.HandlerFunc {
 
 			// If we have no alternate sign address, or if validating with the
 			// alt sign addr fails, return an error to the client.
-			if altSigData == nil || validateSignature(reqBytes, altSigData.AltSignAddr, c) != nil {
+			if altSigData == (database.AltSignAddrData{}) || validateSignature(reqBytes, altSigData.AltSignAddr, c) != nil {
 				log.Warnf("%s: Bad signature (clientIP=%s, ticketHash=%s)", funcName, c.ClientIP(), hash)
 				sendError(errBadSignature, c)
 				return

--- a/webapi/setaltsignaddr.go
+++ b/webapi/setaltsignaddr.go
@@ -60,7 +60,7 @@ func setAltSignAddr(c *gin.Context) {
 		sendError(errInternalError, c)
 		return
 	}
-	if currentData != nil {
+	if currentData != (database.AltSignAddrData{}) {
 		msg := "alternate sign address data already exists"
 		log.Warnf("%s: %s (ticketHash=%s)", funcName, msg, ticketHash)
 		sendErrorWithMsg(msg, errBadRequest, c)
@@ -109,11 +109,11 @@ func setAltSignAddr(c *gin.Context) {
 		Request:   reqBytes,
 	}, c)
 
-	data := &database.AltSignAddrData{
+	data := database.AltSignAddrData{
 		AltSignAddr: altSignAddr,
-		Req:         reqBytes,
+		Req:         string(reqBytes),
 		ReqSig:      c.GetHeader("VSP-Client-Signature"),
-		Resp:        []byte(resp),
+		Resp:        resp,
 		RespSig:     respSig,
 	}
 

--- a/webapi/setaltsignaddr_test.go
+++ b/webapi/setaltsignaddr_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 const (
+	// Charset is a list of all req/response characters.
+	charset = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 	// hexCharset is a list of all valid hexadecimal characters.
 	hexCharset = "1234567890abcdef"
 	// sigCharset is a list of all valid request/response signature characters
@@ -194,11 +196,11 @@ func TestSetAltSignAddress(t *testing.T) {
 		}
 
 		if test.isExistingAltSignAddr {
-			data := &database.AltSignAddrData{
+			data := database.AltSignAddrData{
 				AltSignAddr: test.addr,
-				Req:         b,
+				Req:         string(b),
 				ReqSig:      reqSig,
-				Resp:        randBytes(1000),
+				Resp:        randString(96, charset),
 				RespSig:     randString(96, sigCharset),
 			}
 			if err := db.InsertAltSignAddr(ticketHash, data); err != nil {
@@ -250,13 +252,13 @@ func TestSetAltSignAddress(t *testing.T) {
 		}
 
 		if test.wantCode != http.StatusOK && !test.isExistingAltSignAddr {
-			if altsig != nil {
+			if altsig != (database.AltSignAddrData{}) {
 				t.Fatalf("%q: expected no alt sign addr saved for errored state", test.name)
 			}
 			continue
 		}
 
-		if !bytes.Equal(b, altsig.Req) || altsig.ReqSig != reqSig {
+		if !bytes.Equal(b, []byte(altsig.Req)) || altsig.ReqSig != reqSig {
 			t.Fatalf("%q: expected alt sign addr data different than actual", test.name)
 		}
 	}

--- a/webapi/templates/ticket-search-result.html
+++ b/webapi/templates/ticket-search-result.html
@@ -43,9 +43,13 @@
             <tr>
                 <th>Alternate Signing Address</th>
                 <td>
-                    <a href="{{ addressURL .AltSignAddr }}">
-                        {{ .AltSignAddr }}
+                    {{if .AltSignAddrData.AltSignAddr}}
+                    <a href="{{ addressURL .AltSignAddrData.AltSignAddr }}">
+                        {{ .AltSignAddrData.AltSignAddr }}
                     </a>
+                    {{else}}
+                    Alternate Sigining Address not set.
+                    {{end}}
                 </td>
             </tr>
         </table>
@@ -137,6 +141,38 @@
                         </table>
                     </details>
                     {{end}}
+                </td>
+            </tr>
+        </table>
+
+        <h1>Alternate Signing Address Data</h1>
+        
+        <table id="ticket-table" class="mt-2 mb-4 w-100">
+              <tr>
+                <th>
+                    AltSignAddress Change 
+                </th>
+                <td>
+                    <details>
+                      <table class="my-2">
+                            <tr>
+                                <th>Request</th>
+                                <td>{{ indentJSON .AltSignAddrData.Req }}</td>
+                            </tr>
+                            <tr>
+                                <th>Request<br />Signature</th>
+                                <td>{{ .AltSignAddrData.ReqSig }}</td>
+                            </tr>
+                            <tr>
+                                <th>Response</th>
+                                <td>{{ indentJSON .AltSignAddrData.Resp }}</td>
+                            </tr>
+                            <tr>
+                                <th>Response<br />Signature</th>
+                                <td>{{ .AltSignAddrData.RespSig }}</td>
+                            </tr>
+                        </table>
+                    </details>
                 </td>
             </tr>
         </table>


### PR DESCRIPTION
Before: AltSignAddr req/resp data not shown in admin UI
After with data:
![withdata](https://user-images.githubusercontent.com/57448127/147954632-f5bdad57-a1d4-4a28-b9c1-d25199352378.PNG)
After without data: 
![notset](https://user-images.githubusercontent.com/57448127/147954660-e6578444-238c-4590-935c-97a6b20904eb.PNG)
 